### PR TITLE
CICD-426 - add cf cli autoscaling plugin and enable option to rolling-deploy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,17 @@
-FROM alpine:3.7
+FROM golang:1.11-alpine3.8
+RUN apk update
+RUN apk upgrade
 
-RUN apk update && apk add \ 
-	bash \ 
-	jq \ 
-	curl \ 
-	git \
-	tar \
-	gzip
+RUN apk --no-cache add jq bash git curl tar gzip
 
 # Add jfrog cli
 RUN curl -fL https://getcli.jfrog.io | sh \
     && mv ./jfrog /usr/local/bin/jfrog \
     && chmod 777 /usr/local/bin/jfrog
 
-RUN wget -qO- "https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github" | tar -zx && \
-	mv cf /usr/local/bin && \
-	cf --version
+ADD https://cli.run.pivotal.io/stable?release=linux64-binary /tmp/cf-cli.tgz
+RUN mkdir -p /usr/local/bin && tar -xzf /tmp/cf-cli.tgz -C /usr/local/bin && cf --version && rm -f /tmp/cf-cli.tgz
+RUN git clone https://github.com/cloudfoundry-incubator/app-autoscaler-cli-plugin.git && cd app-autoscaler-cli-plugin && source .envrc && git submodule update --init --recursive && ./scripts/build && cf install-plugin out/ascli -f
 
 RUN addgroup -g 1000 -S pcf && \
 	adduser -u 1000 -S pcf -G pcf

--- a/rolling-deploy.sh
+++ b/rolling-deploy.sh
@@ -126,3 +126,12 @@ cf rename "${APP_NAME}-${BUILD_NUMBER}" "${APP_NAME}"
 
 echo "Deleting the orphaned routes"
 cf delete-orphaned-routes -f
+
+# Enable PCF Autoscaling if autoscale.yml file is found
+curDir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+AUTOSCALECONFIG="${curDir}/src/main/resources/autoscale.yml"
+if [[ -f "${AUTOSCALECONFIG}" ]]; then
+    echo "Enabling autoscaling for ${APP_NAME} in ${CF_ORG} space ${CF_SPACE}"
+    cf configure-autoscaling "${APP_NAME}" "${AUTOSCALECONFIG}"
+    cf enable-autoscaling "${APP_NAME}"
+    fi


### PR DESCRIPTION
Adding support for Autoscaling cf cli plugin. Updated dockerfile to add the autoscaling plugin to the cf cli and updated the rolling deploy to check for the autoscale.yml file in the application repo.
More info: https://merrillcorporation.atlassian.net/wiki/spaces/Product/pages/418775452/PCF+Autoscaling+using+CF+CLI